### PR TITLE
Add support for dependabot, Bump Alpine to 3.15.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Maintain Docker images updated
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily" 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM alpine:3.15 as base
+FROM alpine:3.15.1 as base
 LABEL maintainer="team@appwrite.io"
 
 ENV NODE_ENV production
@@ -23,7 +23,9 @@ RUN npm install \
 # Prod
 FROM base as prod
 
-RUN adduser node -D
+RUN apk -U upgrade && \
+    adduser node -D
+    
 USER node
 WORKDIR /home/node
 


### PR DESCRIPTION
* Bump Alpine to v3.15.1 which introduces fixes for several CVE's including BusyBox, OpenSSL, etc
* Add support for dependabot, to auto create PR's when the base image gets updated.
* Add `apk -U upgrade` to catch any base alpine package that needs to be updated.